### PR TITLE
Adding types/node to fix the build bug

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
   - script: |
       npm install -g @angular/cli
       npm install puppeteer --save-dev
+      npm install --save-dev @types/node
       npm install
     displayName: 'npm install dependencies and build'
     


### PR DESCRIPTION
An issue in one of the modules, namely `types/node` was causing a bug.

Manually installing it and updating it has fixed the issue for now.

Builds are passing and notification is functional (for successful builds)