### PR TITLE
Make pipeline stop using version 9 of angular

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     displayName: 'Install Node.js'
 
   - script: |
-      npm install -g @angular/cli
+      npm install -g @angular/cli@8.1.3
       npm install puppeteer --save-dev
       npm install --save-dev @types/node
       npm install


### PR DESCRIPTION
Version 9 of angular seems to be breaking a few dependencies, so we will force it to install the version of angular that we run in the project locally.