### PR TITLE
B-7 Give the correct sonar instructions + exclude a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ docker run -d --name sonarqube -p 9000:9000 sonarqube
 ### Running sonarqube
 
 1. open bash
-2. `sonar-scanner`
+2. `npm run sonar`
+
+Note: `sonar-scanner` does NOT work. It will fail to exclude the excluded files.
 
 ### Android setup
 

--- a/sonar-project.js
+++ b/sonar-project.js
@@ -8,7 +8,7 @@ const sonarqubeScanner = require('sonarqube-scanner');
             'sonar.projectKey': 'pikaroute',
             'sonar.language': 'ts',
             'sonar.sources': 'src/app',             // include sources from src/app
-            'sonar.exclusions' : '**/*.spec.ts, **/node_modules/**',    // exclude .spec.ts files
+            'sonar.exclusions' : 'src/app/json-typings.d.ts, **/*.spec.ts, **/node_modules/**',    // exclude .spec.ts files
             'sonar.tests': 'src/app',               // include sources from src/app
             'sonar.test.inclusions': '**/*.spec.ts',          // include all ts files
             'sonar.typescript.lcov.reportPaths': 'coverage/lcov.info', // path to lcov.info


### PR DESCRIPTION
The instructions indicate to the developer that the wrong command must be run for sonarqube. `sonar-scanner` does not respect `sonar.exclusions` while `npm run sonar` does. Moreover, a file was excluded as it is not part of our source code and it is reducing test code coverage uselessly
