### PR TITLE
B-8 Gave the selected floor button the correct colours

### DIFF
--- a/src/app/core/components/toggle-floors/toggle-floors.component.scss
+++ b/src/app/core/components/toggle-floors/toggle-floors.component.scss
@@ -17,9 +17,9 @@
 }
 
 .selected {
-  background-color: var(--ion-color-primary-contrast-rgb);
-  color: var(--ion-color-primary-shade);
+  background-color: var(--ion-color-primary);
+  color: var(--ion-color-primary-contrast);
   font-size: 14px;
   padding: 6px 9px 6px 9px;
-  border: 0px hidden var(--ion-color-primary-contrast-rgb);
+  border: 0px hidden var(--ion-color-primary);
 }


### PR DESCRIPTION
Due to a typo in the css, the selected floor in the toggle was displayed with a transparent background and black type font. Now, the selected button uses the correct colour theme