### PR TITLE
B-12 Bathroom POIs not showing in indoor map on mobile 

### DIFF
--- a/src/app/core/factories/indoor-poi-factory.service.ts
+++ b/src/app/core/factories/indoor-poi-factory.service.ts
@@ -44,14 +44,14 @@ export class IndoorPOIFactoryService {
                         iconPath
                     );
                 } else if (IndoorPOIFactoryService.isCoordinatesFor(key, 'BM')) {
-                    const iconPath = '../..//assets/icon/BM-indoor.svg';
+                    const iconPath = '../../../assets/icon/BM-indoor.svg';
                     indoorPOI = this.createRegularPOI(
                         key,
                         poiCoordinates,
                         iconPath
                     );
                 } else if (IndoorPOIFactoryService.isCoordinatesFor(key, 'BW')) {
-                    const iconPath = '../..//assets/icon/BW-indoor.svg';
+                    const iconPath = '../../../assets/icon/BW-indoor.svg';
                     indoorPOI = this.createRegularPOI(
                         key,
                         poiCoordinates,


### PR DESCRIPTION
On mobile, the bathrooms are not appearing on the indoor map.

The picturePaths of the bathrooms are missing some dots. This would explain why we are not able to see them on mobile.