### PR TITLE
Update azure-pipelines.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
     displayName: 'Update modules'
 
   - script: |
-       sed -i 's/G_API_KEY_PLACEHOLDER/'$SECRET_API_KEY'/g' src/index.html
+       sed -i 's/G_API_KEY_PLACEHOLDER/'$SECRET_API_KEY_2'/g' src/index.html
     displayName: 'Update api key for tests'
 
   - script: ng test --watch=false --code-coverage


### PR DESCRIPTION
This PR Fixes the pipeline issue with the Calendar PR merged.

The other key used in the pipeline (Keegan's I believe) seems to not have google calendar permissions enabled. I have added the API key given to me by Johnathan, and the builds are now passing correctly.
