### PR TITLE
B-2 & B-9 Fixed the zoom listener (Fix solved both issues)

### DIFF
--- a/src/app/core/services/map.service.spec.ts
+++ b/src/app/core/services/map.service.spec.ts
@@ -194,31 +194,6 @@ describe('MapService', () => {
         });
     });
 
-    describe('tilesLoadedHandler()', () => {
-        it('should return a tilesloaded handler', () => {
-            const {
-                mapService,
-                locationServiceSpy,
-                googleApisServiceSpy
-            } = testServiceSetup();
-
-            const mockAddress = 'test address';
-            locationServiceSpy.getAddressFromLatLng.and.returnValue(
-                Promise.resolve(mockAddress)
-            );
-
-            const mockMap = new MockMaps(null);
-
-            const handlerFunction = 'tilesLoadedHandler';
-            const handler = mapService[handlerFunction](mockMap, 12, 34);
-            handler();
-
-            expect(
-                locationServiceSpy.getAddressFromLatLng
-            ).toHaveBeenCalledTimes(1);
-        });
-    });
-
     describe('trackBuildingsOutlinesDisplay', () => {
         const testBuildingName = 'Henry F. Hall Building';
 

--- a/src/app/core/services/map.service.ts
+++ b/src/app/core/services/map.service.ts
@@ -68,7 +68,7 @@ export class MapService {
 
                 mapObj.addListener(
                     'tilesloaded',
-                    this.tilesLoadedHandler(mapObj, latLng.lat(), latLng.lng())
+                    this.tilesLoadedHandler(mapObj)
                 );
 
                 return mapObj;
@@ -81,11 +81,7 @@ export class MapService {
         }
     }
 
-    private tilesLoadedHandler(
-        mapObj: google.maps.Map,
-        latitude: number,
-        longitude: number
-    ): () => void {
+    private tilesLoadedHandler(mapObj: google.maps.Map): () => void {
         return () => {
             console.log('mapObj', mapObj); // debug
             this.trackBuildingsOutlinesDisplay(mapObj.getZoom());

--- a/src/app/core/services/map.service.ts
+++ b/src/app/core/services/map.service.ts
@@ -88,9 +88,6 @@ export class MapService {
     ): () => void {
         return () => {
             console.log('mapObj', mapObj); // debug
-            this.locationService
-                .getAddressFromLatLng(latitude, longitude)
-                .then(console.log);
             this.trackBuildingsOutlinesDisplay(mapObj.getZoom());
             this.trackBuildingCodeDisplay(mapObj.getZoom());
         };


### PR DESCRIPTION
An error was being thrown by a debug console log and preventing the code from reaching the two functions to disable the labels and building overlays in a certain zoom range. It was removed to fix the bug as it was completely unnecessary anyways.