### PR TITLE
B-17 Event route options displayed persistently on routes page

### DIFF
--- a/src/app/core/services/session.service.spec.ts
+++ b/src/app/core/services/session.service.spec.ts
@@ -58,4 +58,9 @@ describe('SessionService', () => {
         
     });
 
+    it('should clear the navigation params', () => {
+        service.clearNavigationParams();
+        expect(service.navigationParams).toBeNull();
+    });
+
 });

--- a/src/app/core/services/session.service.ts
+++ b/src/app/core/services/session.service.ts
@@ -48,6 +48,15 @@ export class SessionService {
   }
 
   /**
+   * Clears global navigation params object
+   *
+   */
+  clearNavigationParams(): void {
+    this.navigationParams = null;
+    this.navigationParamsLoaded = false;
+  }
+
+  /**
    * Checks if Navigation params are loaded
    *
    */

--- a/src/app/routes/routes.page.ts
+++ b/src/app/routes/routes.page.ts
@@ -83,11 +83,11 @@ export class RoutesPage implements OnInit, AfterViewInit, OnDestroy {
                 }
             });
     
-        if(this.sessionService.areNavigationParamsLoaded()){
+        if (this.sessionService.areNavigationParamsLoaded()) {
             const navigationParams = this.sessionService.getNavigationParams();
-
             this.isFromCalendar = navigationParams.isRouteToEvent;
             this.eventTo = navigationParams.location;
+            this.sessionService.clearNavigationParams();
         }
     }
 


### PR DESCRIPTION
#160 Cleared navigation params after use on routes page when getting directions to next event